### PR TITLE
added --salte-rating-disabled-color for colors under disabled mode

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -58,11 +58,14 @@
             salte-rating.red {
               --salte-rating-limit-color: rgba(255, 200, 200, 0.9);
               --salte-rating-value-color: rgba(175, 55, 55, 0.9);
+              --salte-rating-disabled-color: rgba(55, 55, 55, 0.4);
             }
           </style>
 
           <salte-rating class="blue" value="[[value]]" icon="favorite"></salte-rating>
           <salte-rating class="red" value="[[value]]" icon="pets"></salte-rating>
+          disabled: 
+          <salte-rating disabled class="red" value="[[value]]" icon="pets"></salte-rating>
 
           <!-- Demo Helper -->
           <paper-slider step="0.1" min="0" max="5" immediate-value="{{value}}" pin="true"></paper-slider>

--- a/salte-rating.html
+++ b/salte-rating.html
@@ -33,7 +33,7 @@ Custom property | Description | Default
         color: var(--salte-rating-limit-color, rgba(200, 200, 200, 0.9));
       }
 
-      :host[disabled] .foreground-rating {
+      :host([disabled]) .foreground-rating {
         color: var(--salte-rating-disabled-color,  rgba(55, 55, 55, 0.9));
       }
 

--- a/salte-rating.html
+++ b/salte-rating.html
@@ -25,7 +25,7 @@ Custom property | Description | Default
         position: relative;
       }
 
-      :host[disabled] .foreground-rating .item {
+      :host([disabled]) .foreground-rating .item {
         cursor: default;
       }
 

--- a/salte-rating.html
+++ b/salte-rating.html
@@ -13,6 +13,7 @@ Custom property | Description | Default
 ----------------|-------------|----------
 `--salte-rating-limit-color` | Color of the max number of items | `rgba(200, 200, 200, 0.9)`
 `--salte-rating-value-color` | Color of the current rating items | `rgba(55, 55, 55, 0.9)`
+`--salte-rating-disabled-color` | Color of the current rating items when disabled | `rgba(55, 55, 55, 0.9)`
 
 @demo demo/index.html
 -->
@@ -30,6 +31,10 @@ Custom property | Description | Default
 
       .background-rating {
         color: var(--salte-rating-limit-color, rgba(200, 200, 200, 0.9));
+      }
+
+      :host[disabled] .foreground-rating {
+        color: var(--salte-rating-disabled-color,  rgba(55, 55, 55, 0.9));
       }
 
       .foreground-rating {


### PR DESCRIPTION
Simple addition to have a different color when the component is on `disabled` mode.